### PR TITLE
change-db-data-type

### DIFF
--- a/src/main/java/com/example/Project_3275_backend/Model/Article.java
+++ b/src/main/java/com/example/Project_3275_backend/Model/Article.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -20,8 +21,11 @@ public class Article {
 	@Column(name = "title")
 	private String title;
 	
-	@Column(name = "content")
-	private String content;
+	@Lob // Use @Lob annotation to specify TEXT data type
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+//	@Column(name = "content")
+//	private String content;
 	
 //	@ManyToOne
 //    @JoinColumn(name = "userId", referencedColumnName = "userId")


### PR DESCRIPTION
The original data type of  "Content" in Article table is VARCHAR which can only store limited characters. By changing the data type to "TEXT", the stored length can be longer.